### PR TITLE
Tin/parse args in yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 run_*/
 
+# Cluster related
+condor/
+entity/ent-bert-ctx0/
+entity/ent-bert-ctx300/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/entity/entityModel.py
+++ b/entity/entityModel.py
@@ -206,20 +206,20 @@ class EntityModel():
     def __init__(self, args, num_ner_labels) -> None:
         super().__init__()
 
-        bert_model_name = args.model
+        bert_model_name = args['model']
         vocab_name = bert_model_name
 
-        if args.bert_model_dir is not None:
-            bert_model_name = str(args.bert_model_dir) + '/'
+        if args['bert_model_dir'] is not None:
+            bert_model_name = str(args['bert_model_dir']) + '/'
             vocab_name = bert_model_name
             logger.info('Loading BERT model from {}'.format(bert_model_name))
 
-        if args.use_albert:
+        if args['use_albert']:
             self.tokenizer = AlbertTokenizer.from_pretrained(vocab_name)
             self.bert_model = AlbertForEntity.from_pretrained(
                 bert_model_name,
                 num_ner_labels=num_ner_labels,
-                max_span_length=args.max_span_length,
+                max_span_length=args['max_span_length'],
                 return_dict=False,
                 ignore_mismatched_sizes=True)
         else:
@@ -227,7 +227,7 @@ class EntityModel():
             self.bert_model = BertForEntity.from_pretrained(
                 bert_model_name,
                 num_ner_labels=num_ner_labels,
-                max_span_length=args.max_span_length,
+                max_span_length=args['max_span_length'],
                 return_dict=False,
                 ignore_mismatched_sizes=True)
 

--- a/run_entity_model.py
+++ b/run_entity_model.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 import random
 import time
-import jsonargparse
+import yaml
 import torch
 
 torch.cuda.empty_cache()
@@ -89,11 +89,11 @@ def get_labelmap(label_list):
 
 
 def save_model(model, args):
-    logger.info('Saving model to %s...' % (args.output_dir))
+    logger.info('Saving model to %s...' % (args['output_dir']))
     model_to_save = model.bert_model.module if hasattr(
         model.bert_model, 'module') else model.bert_model
-    model_to_save.save_pretrained(args.output_dir)
-    model.tokenizer.save_pretrained(args.output_dir)
+    model_to_save.save_pretrained(args['output_dir'])
+    model.tokenizer.save_pretrained(args['output_dir'])
 
 
 def evaluate(model, batches, tot_gold):
@@ -138,169 +138,64 @@ def setseed(seed):
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
 
-def get_parser():
-    parser = jsonargparse.ArgumentParser()
 
-    parser.add_argument("--config", 
-                        action=jsonargparse.ActionConfigFile)
+def parse_yaml(f_path):
+    with open(f_path, 'r') as f:
+        try:
+            args = yaml.safe_load(f)
+            return args
+        except yaml.YAMLError as exc:
+            print(exc)
 
-    parser.add_argument('--task',
-                        type=str,
-                        default='faithlife',
-                        choices=['faithlife'])
-
-    parser.add_argument('--data_dir',
-                        type=str,
-                        default='data',
-                        help="path to the preprocessed dataset")
-    parser.add_argument('--output_dir',
-                        type=str,
-                        default='entity/entity_output',
-                        help="output directory of the entity model")
-
-    parser.add_argument('--max_span_length',
-                        type=int,
-                        default=8,
-                        help=("spans w/ length up to max_span_length"+
-                            " are considered as candidates"))
-    parser.add_argument('--train_batch_size',
-                        type=int,
-                        default=32,
-                        help="batch size during training")
-    parser.add_argument('--eval_batch_size',
-                        type=int,
-                        default=32,
-                        help="batch size during inference")
-    parser.add_argument('--learning_rate',
-                        type=float,
-                        default=1e-5,
-                        help="learning rate for the BERT encoder")
-    parser.add_argument('--task_learning_rate',
-                        type=float,
-                        default=1e-4,
-                        help="learning rate for task-specific parameters")
-    parser.add_argument('--warmup_proportion',
-                        type=float,
-                        default=0.1,
-                        help="ratio of the warmup steps to the total steps")
-    parser.add_argument('--num_epoch',
-                        type=int,
-                        default=100,
-                        help="number of the training epochs")
-    parser.add_argument('--print_loss_step',
-                        type=int,
-                        default=100,
-                        help="how often logging loss val in training")
-    parser.add_argument('--eval_per_epoch',
-                        type=int,
-                        default=1,
-                        help="how often eval model on dev set in training")
-    parser.add_argument("--bertadam",
-                        action="store_true",
-                        help="If bertadam, then set correct_bias = False")
-
-    parser.add_argument('--do_train',
-                        action='store_true',
-                        help="whether to run training")
-    parser.add_argument('--train_shuffle',
-                        action='store_true',
-                        help="whether to train with randomly shuffled data")
-
-    parser.add_argument('--do_eval_dev',
-                        action='store_true',
-                        help="whether to run evaluation on dev set")
-    parser.add_argument('--do_eval_test',
-                        action='store_true',
-                        help="whether to evaluate on test set")
-
-    parser.add_argument('--dev_pred_filename',
-                        type=str,
-                        default="ent_pred_dev.json",
-                        help="the prediction filename for the dev set")
-    parser.add_argument('--test_pred_filename',
-                        type=str,
-                        default="ent_pred_test.json",
-                        help="the prediction filename for the test set")
-
-    parser.add_argument('--use_albert',
-                        action='store_true',
-                        help="whether to use ALBERT model")
-    parser.add_argument('--model',
-                        type=str,
-                        default='bert-base-uncased',
-                        help="the base model name (a huggingface model)")
-    parser.add_argument('--bert_model_dir',
-                        type=str,
-                        default=None,
-                        help="the base model directory")
-
-    parser.add_argument('--seed',
-                        type=int,
-                        default=0)
-
-    parser.add_argument('--context_window',
-                        type=int,
-                        default=0,
-                        help="the context window size W for the entity model")
-
-    return parser
-
-def get_args():
-    parser = get_parser()
-    args = parser.parse_args()
-
-    args.train_data = os.path.join(args.data_dir, 'train.json')
-    args.dev_data = os.path.join(args.data_dir, 'dev.json')
-    args.test_data = os.path.join(args.data_dir, 'test.json')
-
-    return args
 
 if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit("Invalid args")
 
-    args = get_args()
+    args = parse_yaml(sys.argv[1])
 
-    if 'albert' in args.model:
-        logger.info('Use Albert: %s' % args.model)
-        args.use_albert = True
+    if 'albert' in args['model']:
+        logger.info('Use Albert: %s' % args['model'])
+        args['use_albert'] = True
 
-    setseed(args.seed)
+    setseed(args['seed'])
 
-    if not os.path.exists(args.output_dir):
-        os.makedirs(args.output_dir)
+    if not os.path.exists(args['output_dir']):
+        os.makedirs(args['output_dir'])
 
-    if args.do_train:
+    if args['do_train']:
         logger.addHandler(
-            logging.FileHandler(os.path.join(args.output_dir, "train.log"),
+            logging.FileHandler(os.path.join(args['output_dir'], "train.log"),
                                 'w'))
     else:
         logger.addHandler(
-            logging.FileHandler(os.path.join(args.output_dir, "eval.log"),
+            logging.FileHandler(os.path.join(args['output_dir'], "eval.log"),
                                 'w'))
 
     logger.info(sys.argv)
     logger.info(args)
 
-    ner_label2id, ner_id2label = get_labelmap(task_ner_labels[args.task])
+    ner_label2id, ner_id2label = get_labelmap(task_ner_labels[args['task']])
 
-    num_ner_labels = len(task_ner_labels[args.task]) + 1
+    num_ner_labels = len(task_ner_labels[args['task']]) + 1
     model = EntityModel(args, num_ner_labels=num_ner_labels)
 
-    dev_data = Dataset(args.dev_data)
+    dev_data = Dataset(args['dev_data'])
     dev_samples, dev_ner = convert_dataset_to_samples(
         dev_data,
-        args.max_span_length,
+        args['max_span_length'],
         ner_label2id=ner_label2id,
-        context_window=args.context_window)
-    dev_batches = batchify(dev_samples, args.eval_batch_size)
+        context_window=args['context_window'])
+    dev_batches = batchify(dev_samples, args['eval_batch_size'])
 
-    if args.do_train:
-        train_data = Dataset(args.train_data)
+    if args['do_train']:
+        train_data = Dataset(args['train_data'])
         train_samples, train_ner = convert_dataset_to_samples(
             train_data,
-            args.max_span_length,
+            args['max_span_length'],
             ner_label2id=ner_label2id,
-            context_window=args.context_window)
-        train_batches = batchify(train_samples, args.train_batch_size)
+            context_window=args['context_window'])
+        train_batches = batchify(train_samples, args['train_batch_size'])
         best_result = 0.0
 
         param_optimizer = list(model.bert_model.named_parameters())
@@ -308,21 +203,21 @@ if __name__ == '__main__':
             'params': [p for n, p in param_optimizer if 'bert' in n]
         }, {
             'params': [p for n, p in param_optimizer if 'bert' not in n],
-            'lr': args.task_learning_rate
+            'lr': args['task_learning_rate']
         }]
         optimizer = AdamW(optimizer_grouped_parameters,
-                          lr=args.learning_rate,
-                          correct_bias=not (args.bertadam))
-        t_total = len(train_batches) * args.num_epoch
+                          lr=args['learning_rate'],
+                          correct_bias=not (args['bertadam']))
+        t_total = len(train_batches) * args['num_epoch']
         scheduler = get_linear_schedule_with_warmup(
-            optimizer, int(t_total * args.warmup_proportion), t_total)
+            optimizer, int(t_total * args['warmup_proportion']), t_total)
 
         tr_loss = 0
         tr_examples = 0
         global_step = 0
-        eval_step = len(train_batches) // args.eval_per_epoch
-        for _ in tqdm(range(args.num_epoch)):
-            if args.train_shuffle:
+        eval_step = len(train_batches) // args['eval_per_epoch']
+        for _ in tqdm(range(args['num_epoch'])):
+            if args['train_shuffle']:
                 random.shuffle(train_batches)
             for i in tqdm(range(len(train_batches))):
                 output_dict = model.run_batch(train_batches[i], training=True)
@@ -337,7 +232,7 @@ if __name__ == '__main__':
                 scheduler.step()
                 optimizer.zero_grad()
 
-                if global_step % args.print_loss_step == 0:
+                if global_step % args['print_loss_step'] == 0:
                     logger.info('Epoch=%d, iter=%d, loss=%.5f' %
                                 (_, i, tr_loss / tr_examples))
                     tr_loss = 0
@@ -351,41 +246,42 @@ if __name__ == '__main__':
                                     (_, f1 * 100))
                         save_model(model, args)
 
-    if args.do_eval_dev:
-        args.bert_model_dir = args.output_dir
+    if args['do_eval_dev']:
+        args['bert_model_dir'] = args['output_dir']
         model = EntityModel(args, num_ner_labels=num_ner_labels)
 
-        test_data = Dataset(args.dev_data)
-        prediction_file = os.path.join(args.output_dir,
-                                        args.dev_pred_filename)
+        test_data = Dataset(args['dev_data'])
+        prediction_file = os.path.join(args['output_dir'],
+                                        args['dev_pred_filename'])
 
         test_samples, test_ner = convert_dataset_to_samples(
             test_data,
-            args.max_span_length,
+            args['max_span_length'],
             ner_label2id=ner_label2id,
-            context_window=args.context_window)
-        test_batches = batchify(test_samples, args.eval_batch_size)
+            context_window=args['context_window'])
+        test_batches = batchify(test_samples, args['eval_batch_size'])
         evaluate(model, test_batches, test_ner)
         output_ner_predictions(model,
                                test_batches,
                                test_data,
                                output_file=prediction_file)
 
-    if args.do_eval_test:
-        args.bert_model_dir = args.output_dir
+    if args['do_eval_test']:
+        args['bert_model_dir'] = args['output_dir']
         model = EntityModel(args, num_ner_labels=num_ner_labels)
-        test_data = Dataset(args.test_data)
-        prediction_file = os.path.join(args.output_dir,
-                                        args.test_pred_filename)
+        test_data = Dataset(args['test_data'])
+        prediction_file = os.path.join(args['output_dir'],
+                                        args['test_pred_filename'])
         test_samples, test_ner = convert_dataset_to_samples(
             test_data,
-            args.max_span_length,
+            args['max_span_length'],
             ner_label2id=ner_label2id,
-            context_window=args.context_window)
-        test_batches = batchify(test_samples, args.eval_batch_size)
+            context_window=args['context_window'])
+        test_batches = batchify(test_samples, args['eval_batch_size'])
         evaluate(model, test_batches, test_ner)
         output_ner_predictions(model,
                                test_batches,
                                test_data,
                                output_file=prediction_file)
+
 


### PR DESCRIPTION
- Allow `run_entity_model.py` to read in arguments stored inside a YAML file.
- Modify `--eval_test` and `--run_eval` arg options so both can happen in the same run, instead of running 1 by 1